### PR TITLE
fix: upgrade av to 8.0.0

### DIFF
--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -8,7 +8,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/ambianic/peerjs-python
 license = Apache Software License 2.0
-classifiers = 
+classifiers =
 	Development Status :: 4 - Beta
 	Programming Language :: Python :: 3
 	License :: OSI Approved :: Apache Software License
@@ -20,8 +20,8 @@ classifiers =
 [options]
 packages = find_namespace:
 python_requires = >=3.7
-install_requires = 
-	av~=6.2
+install_requires =
+	av~=8.0.0
 	aiortc>=0.9
 	websockets>=8.1
 	aiohttp>=3.6
@@ -49,4 +49,3 @@ disallow_untyped_calls = True
 disallow_untyped_decorators = True
 mypy_path = stubs
 strict_optional = False
-


### PR DESCRIPTION
after upgrading to ubuntu 20.04 (python 3.8) a dependency error prevent from running . Upgrading `av` to a suggested version fixed it.