### PR TITLE
feat: expose stun servers config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Enables [Progressive Web Apps](https://developer.mozilla.org/en-US/docs/Web/Prog
 
 See Ambianic UI [PNP module](https://github.com/ambianic/ambianic-ui/blob/master/src/store/pnp.js) for a real-world example how PeerJS Python is used with PnP and HTTP Proxy.
 
+- *Setting additional STUN servers* is possible  using the `STUN_SERVERS` env variable, separated by semicolon (`;`). Eg. `STUN_SERVERS=stun:example1.org:19302;stun:example2.org:19302;`
+
 ## Dependencies
 
 Uses [aiortc](https://github.com/aiortc/aiortc) as Python WebRTC provider. This requires installing a few native dependencies for audio/video media processing.

--- a/src/peerjs/ext/http-proxy.py
+++ b/src/peerjs/ext/http-proxy.py
@@ -100,13 +100,13 @@ def _loadConfig():
         with conf_file.open() as infile:
             config = json.load(infile)
         savedPeerId = config.get('peerId', None)
-        if not "host" in config.keys():
+        if "host" not in config.keys():
             config["host"] = AMBIANIC_PNP_HOST
-        if not "port" in config.keys():
+        if "port" not in config.keys():
             config["port"] = AMBIANIC_PNP_PORT
-        if not "secure" in config.keys():
+        if "secure" not in config.keys():
             config["secure"] = AMBIANIC_PNP_SECURE
-        if not "stun_servers" in config.keys():
+        if "stun_servers" not in config.keys():
             config["stun_servers"] = default_stun_servers
 
 

--- a/src/peerjs/util.py
+++ b/src/peerjs/util.py
@@ -4,6 +4,7 @@ import math
 import re
 from dataclasses import dataclass
 from uuid import uuid4
+import os
 # import msgpack
 
 from aiortc.rtcconfiguration import RTCConfiguration, RTCIceServer
@@ -13,16 +14,24 @@ from aiortc.rtcconfiguration import RTCConfiguration, RTCIceServer
 
 log = logging.getLogger(__name__)
 
+
+default_stun_servers = [
+    "stun:stun.l.google.com:19302"
+]
+
+stun_servers = [] + default_stun_servers
+
+server_list_str = os.environ.get("STUN_SERVERS")
+if server_list_str:
+    server_list = server_list_str.split(";")
+    for el in server_list:
+        default_stun_servers.append(el)
+
 DEFAULT_CONFIG = RTCConfiguration(
     iceServers=[
-        RTCIceServer(
-            urls=[
-                "stun:stun.l.google.com:19302"
-                ]
-                )
-        ]
-    )
-
+        RTCIceServer(urls=default_stun_servers)
+    ]
+)
 
 @dataclass
 class UtilSupports:

--- a/src/peerjs/util.py
+++ b/src/peerjs/util.py
@@ -19,14 +19,6 @@ default_stun_servers = [
     "stun:stun.l.google.com:19302"
 ]
 
-stun_servers = [] + default_stun_servers
-
-server_list_str = os.environ.get("STUN_SERVERS")
-if server_list_str:
-    server_list = server_list_str.split(";")
-    for el in server_list:
-        default_stun_servers.append(el)
-
 DEFAULT_CONFIG = RTCConfiguration(
     iceServers=[
         RTCIceServer(urls=default_stun_servers)


### PR DESCRIPTION
First iteration to expose configurable stun servers and some more parameters. Configuration is stored in `.peerjsrc` currently but can be moved to an external API initialization in future. 