### PR TITLE
docs: add supported python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Initial working prototype completed. PeerJS Python is now able to connect over W
 -  [x] Release initial version to PyPi.
 -  [ ] >90% code coverage with CI tests.
 -  [ ] Port media support.
+-  [x] support for python 3.7 & python 3.8
+-  [ ] support for python 3.9
+
   
 ## Code Examples
 


### PR DESCRIPTION
I was using `python 3.9` in my project and was not able to install `peerjs` because python 3.9 is not supported for this package yet.
I think it would be useful if you add the supported python version in the `readme` file.
thank you for your time and effort on maintaining this project.